### PR TITLE
Fix FS compilation by changing MKSPIFFSTOOL env

### DIFF
--- a/pio_erfs32.py
+++ b/pio_erfs32.py
@@ -8,5 +8,5 @@ Import("env")
 
 
 env.Replace(
-    MKSPIFFSTOOL="./mkerfs32.py"
+    MKFSTOOL="./mkerfs32.py"
 )


### PR DESCRIPTION
La compilation du filesystem ne prenait pas en compte le script `mkerfs32`.
La variable d'environnement MKSPIFFSTOOL semble avoir été changée en MKFSTOOL par PlatformIO.